### PR TITLE
fix: fix ocr scanning method name mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ import { labelImage } from "vision-camera-image-labeler";
 // ...
 const frameProcessor = useFrameProcessor((frame) => {
   'worklet';
-  const scannedOcr = scanOCR(frame);
+  const scannedOcr = __scanOCR(frame);
 }, []);
 ```
 


### PR DESCRIPTION
The global `__scanOCR` method specified in `babel.config.js` does not match the method called in the example `scanOCR`.
It throws error saying `Can't find variable: scanOCR`