### PR TITLE
Adds hook to allow easier usage of the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,31 @@ module.exports = {
 
 ## Usage
 
+### With Hook:
+
+```tsx
+import { useScanOCR } from "vision-camera-ocr";
+
+// ...
+const [frameProcessor, ocrData] = useScanOCR();
+React.useEffect(() => {
+  // This effect will run every time the frameprocessor gets different data.
+  if (ocrData) {
+    console.log('Got Data: ', ocrData);
+  }
+}, [ocrData]);
+
+return (
+  <Camera
+    // ...
+    frameProcessor={frameProcessor}
+    frameProcessorFps='auto'
+  />
+)
+```
+
+### Manually:
+
 ```js
 import { scanOCR } from "vision-camera-ocr";
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ module.exports = {
 ## Usage
 
 ```js
-import { labelImage } from "vision-camera-image-labeler";
+import { scanOCR } from "vision-camera-ocr";
 
 // ...
 const frameProcessor = useFrameProcessor((frame) => {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,7 +1,5 @@
 /* eslint-disable react-native/no-inline-styles */
 import * as React from 'react';
-
-import { runOnJS } from 'react-native-reanimated';
 import {
   StyleSheet,
   View,
@@ -12,25 +10,19 @@ import {
   Alert,
   Clipboard,
 } from 'react-native';
-import { OCRFrame, scanOCR } from 'vision-camera-ocr';
+import { useScanOCR } from 'vision-camera-ocr';
 import {
   useCameraDevices,
-  useFrameProcessor,
   Camera,
 } from 'react-native-vision-camera';
 
 export default function App() {
   const [hasPermission, setHasPermission] = React.useState(false);
-  const [ocr, setOcr] = React.useState<OCRFrame>();
   const [pixelRatio, setPixelRatio] = React.useState<number>(1);
   const devices = useCameraDevices();
   const device = devices.back;
 
-  const frameProcessor = useFrameProcessor((frame) => {
-    'worklet';
-    const data = scanOCR(frame);
-    runOnJS(setOcr)(data);
-  }, []);
+  const [frameProcessor, ocr] = useScanOCR();
 
   React.useEffect(() => {
     (async () => {

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+import { Frame, useFrameProcessor } from 'react-native-vision-camera';
+import { runOnJS } from 'react-native-reanimated';
+import { OCRFrame, scanOCR } from './index';
+
+export function useScanOCR(): [(frame: Frame) => void, OCRFrame | undefined] {
+  const [ocrData, setOCRData] = useState<OCRFrame>();
+
+  const frameProcessor = useFrameProcessor((frame) => {
+    'worklet';
+
+    const detectedOCR = scanOCR(frame);
+    runOnJS(setOCRData)(detectedOCR);
+  }, []);
+
+  return [frameProcessor, ocrData];
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -51,3 +51,5 @@ export function scanOCR(frame: Frame): OCRFrame {
   // @ts-ignore
   return __scanOCR(frame);
 }
+
+export * from './hook';


### PR DESCRIPTION
I added a hook, similar to the one in [vision-camera-code-scanner](https://github.com/rodgomesc/vision-camera-code-scanner/blob/master/src/hook.tsx) so you don't have to manually deal with all the frame processor worklet and javascript thread stuff yourself.

Now, you can just do:

```tsx
import { useScanOCR } from "vision-camera-ocr";

// ...
const [frameProcessor, ocrData] = useScanOCR();
React.useEffect(() => {
  // This effect will run every time the frameprocessor gets different data.
  if (ocrData) {
    console.log('Got Data: ', ocrData);
  }
}, [ocrData]);

return (
  <Camera
    // ...
    frameProcessor={frameProcessor}
    frameProcessorFps='auto'
  />
)
```

---

I also fixed a typo in the readme usage section that should close #7 