### PR TITLE
Move GIF to better spot in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-<div align="right">
-<img align="right" src="docs/demo.gif">
+# vision-camera-ocr
+
+<div>
+<img src="docs/demo.gif" height=500>
 </div>
 
-# vision-camera-ocr
+## Summary
 
 A [VisionCamera](https://github.com/mrousavy/react-native-vision-camera) Frame Processor Plugin to preform text detection on images using [**MLKit Vision** Text Recognition](https://developers.google.com/ml-kit/vision/text-recognition).
 


### PR DESCRIPTION
Great library!

When going through installation, the GIF placement just made it a bit hard to read the docs, so I just moved it above text. Hope that's ok!

I also noticed the example was importing the wrong function from the wrong library, but I think that's fixed in #7 