### PR TITLE
Fix android empty elements array

### DIFF
--- a/android/src/main/java/com/visioncameraocr/OCRFrameProcessorPlugin.kt
+++ b/android/src/main/java/com/visioncameraocr/OCRFrameProcessorPlugin.kt
@@ -60,6 +60,8 @@ class OCRFrameProcessorPlugin: FrameProcessorPlugin("scanOCR") {
             elementMap.putString("text", element.text)
             elementMap.putArray("cornerPoints", element.cornerPoints?.let { getCornerPoints(it) })
             elementMap.putMap("frame", getFrame(element.boundingBox))
+
+            elementArray.pushMap(elementMap)
         }
         return elementArray
     }


### PR DESCRIPTION
Currently, on Android, the line elements array is always empty.